### PR TITLE
perf: remove usage of named attribute accesses on bunches

### DIFF
--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -122,6 +122,9 @@ class TestTraitType(TestCase):
         a.tt = 10
         self.assertEqual(a.tt, -1)
 
+        a = A(tt=11)
+        self.assertEqual(a.tt, -1)
+
     def test_default_validate(self):
         class MyIntTT(TraitType):
             def validate(self, obj, value):
@@ -2030,6 +2033,23 @@ class TestValidationHook(TestCase):
         u.even = 2  # OK
         with self.assertRaises(TraitError):
             u.even = 3  # Trait Error
+
+    def test_validate_used(self):
+        """Verify that the validate value is being used"""
+
+        class FixedValue(HasTraits):
+            value = Int(0)
+
+            @validate("value")
+            def _value_validate(self, proposal):
+                return -1
+
+        u = FixedValue(value=2)
+        assert u.value == -1
+
+        u = FixedValue()
+        u.value = 3
+        assert u.value == -1
 
 
 class TestLink(TestCase):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2616,6 +2616,9 @@ class Bool(TraitType):
         else:
             raise ValueError("%r is not 1, 0, true, or false")
 
+    def subclass_init(self, cls):
+        pass  # fully opt out of instance_init
+
 
 class CBool(Bool):
     """A casting version of the boolean trait."""
@@ -2666,6 +2669,9 @@ class Enum(TraitType):
             return self.validate(None, s)
         except TraitError:
             return _safe_literal_eval(s)
+
+    def subclass_init(self, cls):
+        pass  # fully opt out of instance_init
 
 
 class CaselessStrEnum(Enum):

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -989,6 +989,7 @@ class MetaHasTraits(MetaHasDescriptors):
         cls._trait_default_generators = {}
         # also looking at base classes
         cls._all_trait_default_generators = {}
+        cls._traits = {}
 
         super().setup_class(classdict)
 
@@ -997,6 +998,7 @@ class MetaHasTraits(MetaHasDescriptors):
         for name in dir(cls):
             value = getattr(cls, name)
             if isinstance(value, TraitType):
+                cls._traits[name] = value
                 trait = value
                 default_method_name = "_%s_default" % name
                 try:
@@ -1661,7 +1663,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         the output.  If a metadata key doesn't exist, None will be passed
         to the function.
         """
-        traits = dict([memb for memb in getmembers(cls) if isinstance(memb[1], TraitType)])
+        traits = cls._traits.copy()
 
         if len(metadata) == 0:
             return traits
@@ -1693,7 +1695,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
 
     def has_trait(self, name):
         """Returns True if the object has a trait with the specified name."""
-        return isinstance(getattr(self.__class__, name, None), TraitType)
+        return name in self._traits
 
     def trait_has_value(self, name):
         """Returns True if the specified trait has a value.
@@ -1791,9 +1793,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         the output.  If a metadata key doesn't exist, None will be passed
         to the function.
         """
-        traits = dict(
-            [memb for memb in getmembers(self.__class__) if isinstance(memb[1], TraitType)]
-        )
+        traits = self._traits.copy()
 
         if len(metadata) == 0:
             return traits

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1349,7 +1349,9 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             changed = set(kwargs) & set(self._traits)
             for key in changed:
                 change = changes[key]
-                self._traits[key]._cross_validate(self, change.new)
+                value = self._traits[key]._cross_validate(self, getattr(self, key))
+                self.set_trait(key, value)
+                changes[key].new = value
             self._cross_validation_lock = False
             # Restore method retrieval from class
             del self.notify_change

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1060,7 +1060,7 @@ class MetaHasTraits(MetaHasDescriptors):
                     elif type(trait) == Union and trait.default_value is None:
                         cls._static_immutable_initial_values[name] = None
                     elif (
-                        type(trait) == Dict
+                        isinstance(trait, Instance)
                         and trait.default_args is None
                         and trait.default_kwargs is None
                         and trait.allow_none

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1348,7 +1348,6 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             # notify and cross validate all trait changes that were set in kwargs
             changed = set(kwargs) & set(self._traits)
             for key in changed:
-                change = changes[key]
                 value = self._traits[key]._cross_validate(self, getattr(self, key))
                 self.set_trait(key, value)
                 changes[key].new = value
@@ -1356,7 +1355,6 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             # Restore method retrieval from class
             del self.notify_change
             for key in changed:
-                change = changes[key]
                 self.notify_change(changes[key])
 
         try:

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1284,9 +1284,10 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         self = args[0]
         args = args[1:]
 
-        self._trait_values = {
-            k: v for k, v in self._static_immutable_initial_values.items() if k not in kwargs
-        }
+        # although we'd prefer to set only the initial values not present
+        # in kwargs, we will overwrite them in `__init__`, and simply making
+        # a copy of a dict is faster than checking for each key.
+        self._trait_values = self._static_immutable_initial_values.copy()
         self._trait_notifiers = {}
         self._trait_validators = {}
         self._cross_validation_lock = False

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1048,6 +1048,15 @@ class MetaHasTraits(MetaHasDescriptors):
                         isinstance(trait.default_value, (str, int, float, bool)) or none_ok
                     ):
                         cls._static_immutable_initial_values[name] = trait.default_value
+                    elif type(trait) == Union and trait.default_value is None:
+                        cls._static_immutable_initial_values[name] = None
+                    elif (
+                        type(trait) == Dict
+                        and trait.default_args is None
+                        and trait.default_kwargs is None
+                        and trait.allow_none
+                    ):
+                        cls._static_immutable_initial_values[name] = None
 
                     # we always add it, because a class may change when we call add_trait
                     # and then the instance may not have all the _static_immutable_initial_values

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1024,15 +1024,15 @@ class MetaHasTraits(MetaHasDescriptors):
                     none_ok = trait.default_value is None and trait.allow_none
                     if (
                         type(trait) in [CInt, Int]
-                        and trait.min is None
-                        and trait.max is None
+                        and trait.min is None  # type: ignore[attr-defined]
+                        and trait.max is None  # type: ignore[attr-defined]
                         and (isinstance(trait.default_value, int) or none_ok)
                     ):
                         cls._static_immutable_initial_values[name] = trait.default_value
                     elif (
                         type(trait) in [CFloat, Float]
-                        and trait.min is None
-                        and trait.max is None
+                        and trait.min is None  # type: ignore[attr-defined]
+                        and trait.max is None  # type: ignore[attr-defined]
                         and (isinstance(trait.default_value, float) or none_ok)
                     ):
                         cls._static_immutable_initial_values[name] = trait.default_value

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -654,8 +654,14 @@ class TraitType(BaseDescriptor):
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            with obj.cross_validation_lock:
+            # Using a context manager has a large runtime overhead, so we
+            # write out the obj.cross_validation_lock call here.
+            _cross_validation_lock = obj._cross_validation_lock
+            try:
+                obj._cross_validation_lock = True
                 value = self._validate(obj, default)
+            finally:
+                obj._cross_validation_lock = _cross_validation_lock
             obj._trait_values[self.name] = value
             obj._notify_observers(
                 Bunch(

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1011,7 +1011,7 @@ class MetaHasTraits(MetaHasDescriptors):
                         cls._all_trait_default_generators[name] = c.__dict__[default_method_name]
                         break
                     if name in c.__dict__.get("_trait_default_generators", {}):
-                        cls._all_trait_default_generators[name] = c._trait_default_generators[name]
+                        cls._all_trait_default_generators[name] = c._trait_default_generators[name]  # type: ignore[attr-defined]
                         break
                 else:
                     cls._all_trait_default_generators[name] = trait.default
@@ -1238,6 +1238,8 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
     _trait_notifiers: t.Dict[str, t.Any]
     _trait_validators: t.Dict[str, t.Any]
     _cross_validation_lock: bool
+    _traits: t.Dict[str, t.Any]
+    _all_trait_default_generators: t.Dict[str, t.Any]
 
     def setup_instance(*args, **kwargs):
         # Pass self as args[0] to allow "self" as keyword argument
@@ -1423,7 +1425,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         if name in self._trait_notifiers:
             callables.extend(self._trait_notifiers.get(name, {}).get(type, []))
             callables.extend(self._trait_notifiers.get(name, {}).get(All, []))
-        if All in self._trait_notifiers:
+        if All in self._trait_notifiers:  # type:ignore[comparison-overlap]
             callables.extend(
                 self._trait_notifiers.get(All, {}).get(type, [])  # type:ignore[call-overload]
             )

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1350,7 +1350,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
             for key in changed:
                 value = self._traits[key]._cross_validate(self, getattr(self, key))
                 self.set_trait(key, value)
-                changes[key].new = value
+                changes[key]['new'] = value
             self._cross_validation_lock = False
             # Restore method retrieval from class
             del self.notify_change
@@ -1511,7 +1511,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         if not isinstance(event, Bunch):
             # cast to bunch if given a dict
             event = Bunch(event)
-        name, type = event.name, event.type
+        name, type = event['name'], event['type']
 
         callables = []
         if name in self._trait_notifiers:
@@ -1527,7 +1527,7 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
 
         # Now static ones
         magic_name = "_%s_changed" % name
-        if event.type == "change" and hasattr(self, magic_name):
+        if event['type'] == "change" and hasattr(self, magic_name):
             class_value = getattr(self.__class__, magic_name)
             if not isinstance(class_value, ObserveHandler):
                 _deprecated_method(

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1414,14 +1414,16 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         name, type = event.name, event.type
 
         callables = []
-        callables.extend(self._trait_notifiers.get(name, {}).get(type, []))
-        callables.extend(self._trait_notifiers.get(name, {}).get(All, []))
-        callables.extend(
-            self._trait_notifiers.get(All, {}).get(type, [])  # type:ignore[call-overload]
-        )
-        callables.extend(
-            self._trait_notifiers.get(All, {}).get(All, [])  # type:ignore[call-overload]
-        )
+        if name in self._trait_notifiers:
+            callables.extend(self._trait_notifiers.get(name, {}).get(type, []))
+            callables.extend(self._trait_notifiers.get(name, {}).get(All, []))
+        if All in self._trait_notifiers:
+            callables.extend(
+                self._trait_notifiers.get(All, {}).get(type, [])  # type:ignore[call-overload]
+            )
+            callables.extend(
+                self._trait_notifiers.get(All, {}).get(All, [])  # type:ignore[call-overload]
+            )
 
         # Now static ones
         magic_name = "_%s_changed" % name

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -977,8 +977,35 @@ class MetaHasTraits(MetaHasDescriptors):
     """A metaclass for HasTraits."""
 
     def setup_class(cls, classdict):
+        # for only the current class
         cls._trait_default_generators = {}
+        # also looking at base classes
+        cls._all_trait_default_generators = {}
+
         super().setup_class(classdict)
+
+        mro = cls.mro()
+
+        for name in dir(cls):
+            value = getattr(cls, name)
+            if isinstance(value, TraitType):
+                trait = value
+                default_method_name = "_%s_default" % name
+                try:
+                    mro_trait = mro[: mro.index(trait.this_class) + 1]  # type:ignore[arg-type]
+                except ValueError:
+                    # this_class not in mro
+                    pass
+                for c in mro_trait:
+                    if default_method_name in c.__dict__:
+                        cls._all_trait_default_generators[name] = c.__dict__[default_method_name]
+                        break
+                    if name in c.__dict__.get("_trait_default_generators", {}):
+                        cls._all_trait_default_generators[name] = c._trait_default_generators[name]
+                        break
+                else:
+                    cls._all_trait_default_generators[name] = trait.default
+
 
 
 def observe(*names, type="change"):
@@ -1720,22 +1747,9 @@ class HasTraits(HasDescriptors, metaclass=MetaHasTraits):
         method_name = "_%s_default" % name
         if method_name in self.__dict__:
             return getattr(self, method_name)
-        cls = self.__class__
-        trait = getattr(cls, name)
-        assert isinstance(trait, TraitType)
-        # truncate mro to the class on which the trait is defined
-        mro = cls.mro()
-        try:
-            mro = mro[: mro.index(trait.this_class) + 1]  # type:ignore[arg-type]
-        except ValueError:
-            # this_class not in mro
-            pass
-        for c in mro:
-            if method_name in c.__dict__:
-                return getattr(c, method_name)
-            if name in c.__dict__.get("_trait_default_generators", {}):
-                return c._trait_default_generators[name]  # type:ignore[attr-defined]
-        return trait.default
+        if method_name in self.__class__.__dict__:
+            return getattr(self.__class__, method_name)
+        return self._all_trait_default_generators[name]
 
     def trait_defaults(self, *names, **metadata):
         """Return a trait's default value or a dictionary of them

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -1015,7 +1015,6 @@ class MetaHasTraits(MetaHasDescriptors):
                     cls._all_trait_default_generators[name] = trait.default
 
 
-
 def observe(*names, type="change"):
     """A decorator which can be used to observe Traits on a class.
 
@@ -1230,7 +1229,6 @@ class HasDescriptors(metaclass=MetaHasDescriptors):
         cls = self.__class__
         for descriptor in cls._descriptors:
             descriptor.instance_init(self)
-
 
 
 class HasTraits(HasDescriptors, metaclass=MetaHasTraits):


### PR DESCRIPTION
Following the investigation in [this comment](https://github.com/ipython/traitlets/pull/777#issuecomment-1285012559), this PR removes any usage of `bunch.name` within traitlets. It's about a 12 character change in total, but for some specific (extremely artificial) benchmarks that have a lot of value changes + some observers on a traitlet, you can get a modest reduction in runtime. 

This PR is totally backwards compatible: it does not change the Bunch interface. It just uses bunches differently internally for a free performance benefits.

I can update this PR to the main branch on the traitlets repo once https://github.com/ipython/traitlets/pull/777 is merged :-)